### PR TITLE
Check for failed invocations which would cause the debugger to crash.

### DIFF
--- a/debugger/makefiles/make_appdbg64g
+++ b/debugger/makefiles/make_appdbg64g
@@ -8,7 +8,7 @@ include util.mak
 
 CC=gcc
 CPP=gcc
-CFLAGS= -c -Wall -Werror
+CFLAGS=-g -c -Wall -Werror -fpic -std=c++0x
 LDFLAGS=-L$(ELF_DIR)
 INCL_KEY=-I
 DIR_KEY=-B
@@ -37,24 +37,20 @@ LIBS = \
 	dbg64g
 
 SRC_FILES = $(addsuffix .cpp,$(SOURCES))
-OBJ_FILES = $(addsuffix .o,$(SOURCES))
-EXECUTABLE = appdbg64g.exe
+OBJ_FILES = $(addprefix $(OBJ_DIR)/,$(addsuffix .o,$(SOURCES)))
+EXECUTABLE = $(addprefix $(ELF_DIR)/,appdbg64g.exe)
 
-all: appdbg64g
-
-.PHONY: $(EXECUTABLE)
-
-appdbg64g: $(EXECUTABLE)
+all: $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJ_FILES)
-	echo $(CPP) $(LDFLAGS) $(addprefix $(OBJ_DIR)/,$(OBJ_FILES)) -o $(addprefix $(ELF_DIR)/,$@)
-	$(CPP) $(LDFLAGS) $(addprefix $(OBJ_DIR)/,$(OBJ_FILES)) -o $(addprefix $(ELF_DIR)/,$@) $(addprefix -l,$(LIBS))
+	echo $(CPP) $(LDFLAGS) $(OBJ_FILES) -o $@
+	$(CPP) $(LDFLAGS) $(OBJ_FILES) -o $@ $(addprefix -l,$(LIBS))
 	$(ECHO) "\n  Debugger Test application has been built successfully.\n"
 
-%.o: %.cpp
-	echo $(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(OBJ_DIR)/,$@)
-	$(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(OBJ_DIR)/,$@)
+$(addprefix $(OBJ_DIR)/,%.o): %.cpp
+	echo $(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
+	$(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
 
-%.o: %.c
-	echo $(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(OBJ_DIR)/,$@)
-	$(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(OBJ_DIR)/,$@)
+$(addprefix $(OBJ_DIR)/,%.o): %.c
+	echo $(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
+	$(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@

--- a/debugger/makefiles/make_cpu_fnc_plugin
+++ b/debugger/makefiles/make_cpu_fnc_plugin
@@ -8,7 +8,7 @@ include util.mak
 
 CC=gcc
 CPP=gcc
-CFLAGS= -c -Wall -Werror -fpic -std=c++0x
+CFLAGS=-g -c -Wall -Werror -fpic -std=c++0x
 LDFLAGS=-shared -L$(PLUGINS_ELF_DIR)/..
 INCL_KEY=-I
 DIR_KEY=-B
@@ -44,24 +44,20 @@ LIBS = \
 	dbg64g
 
 SRC_FILES = $(addsuffix .cpp,$(SOURCES))
-OBJ_FILES = $(addsuffix .o,$(SOURCES))
-EXECUTABLE = cpu_fnc_plugin.so
+OBJ_FILES = $(addprefix $(PLUGINS_OBJ_DIR)/,$(addsuffix .o,$(SOURCES)))
+EXECUTABLE = $(addprefix $(PLUGINS_ELF_DIR)/,cpu_fnc_plugin.so)
 
-all: cpu_fnc_plugin
-
-.PHONY: $(EXECUTABLE)
-
-cpu_fnc_plugin: $(EXECUTABLE)
+all: $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJ_FILES)
-	echo $(CPP) $(LDFLAGS) $(addprefix $(PLUGINS_OBJ_DIR)/,$(OBJ_FILES)) -o $(addprefix $(PLUGINS_ELF_DIR)/,$@)
-	$(CPP) $(LDFLAGS) $(addprefix $(PLUGINS_OBJ_DIR)/,$(OBJ_FILES)) -o $(addprefix $(PLUGINS_ELF_DIR)/,$@) $(addprefix -l,$(LIBS))
+	echo $(CPP) $(LDFLAGS) $(OBJ_FILES) -o $@
+	$(CPP) $(LDFLAGS) $(OBJ_FILES) -o $@ $(addprefix -l,$(LIBS))
 	$(ECHO) "\n  Plugin '"$@"' has been built successfully.\n"
 
-%.o: %.cpp
-	echo $(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
-	$(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
+$(addprefix $(OBJ_DIR)/,%.o): %.cpp
+	echo $(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
+	$(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
 
-%.o: %.c
-	echo $(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
-	$(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
+$(addprefix $(OBJ_DIR)/,%.o): %.c
+	echo $(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
+	$(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@

--- a/debugger/makefiles/make_libdbg64g
+++ b/debugger/makefiles/make_libdbg64g
@@ -8,7 +8,7 @@ include util.mak
 
 CC=gcc
 CPP=gcc
-CFLAGS= -c -Wall -Werror -fpic -std=c++0x -pthread
+CFLAGS=-g -c -Wall -Werror -fpic -std=c++0x -pthread
 LDFLAGS= -shared -pthread
 INCL_KEY=-I
 DIR_KEY=-B
@@ -51,24 +51,20 @@ LIBS = \
 	dl
 
 SRC_FILES = $(addsuffix .cpp,$(SOURCES))
-OBJ_FILES = $(addsuffix .o,$(SOURCES))
-EXECUTABLE = libdbg64g.so
+OBJ_FILES = $(addprefix $(OBJ_DIR)/,$(addsuffix .o,$(SOURCES)))
+EXECUTABLE = $(addprefix $(ELF_DIR)/,libdbg64g.so)
 
-all: libdbg64g
-
-.PHONY: $(EXECUTABLE)
-
-libdbg64g: $(EXECUTABLE)
+all: $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJ_FILES)
-	echo $(CPP) $(LDFLAGS) $(addprefix $(OBJ_DIR)/,$(OBJ_FILES)) -o $(addprefix $(ELF_DIR)/,$@)
-	$(CPP) $(LDFLAGS) $(addprefix $(OBJ_DIR)/,$(OBJ_FILES)) -o $(addprefix $(ELF_DIR)/,$@) $(addprefix -l,$(LIBS))
+	echo $(CPP) $(LDFLAGS) $(OBJ_FILES) -o $@
+	$(CPP) $(LDFLAGS) $(OBJ_FILES) -o $@ $(addprefix -l,$(LIBS))
 	$(ECHO) "\n  Debugger Core Library has been built successfully.\n"
 
-%.o: %.cpp
-	echo $(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(OBJ_DIR)/,$@)
-	$(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(OBJ_DIR)/,$@)
+$(addprefix $(OBJ_DIR)/,%.o): %.cpp
+	echo $(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
+	$(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
 
-%.o: %.c
-	echo $(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(OBJ_DIR)/,$@)
-	$(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(OBJ_DIR)/,$@)
+$(addprefix $(OBJ_DIR)/,%.o): %.c
+	echo $(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
+	$(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@

--- a/debugger/makefiles/make_simple_plugin
+++ b/debugger/makefiles/make_simple_plugin
@@ -8,8 +8,8 @@ include util.mak
 
 CC=gcc
 CPP=gcc
-CFLAGS= -c -g -Wall -Werror -fpic -std=c++0x
-LDFLAGS=-shared -L$(PLUGINS_ELF_DIR)/..
+CFLAGS=-g -c -g -Wall -Werror -fpic -std=c++0x -pthread
+LDFLAGS=-shared -pthread -L$(PLUGINS_ELF_DIR)/..
 INCL_KEY=-I
 DIR_KEY=-B
 
@@ -36,24 +36,20 @@ LIBS = \
 	dbg64g
 
 SRC_FILES = $(addsuffix .cpp,$(SOURCES))
-OBJ_FILES = $(addsuffix .o,$(SOURCES))
-EXECUTABLE = simple_plugin.so
+OBJ_FILES = $(addprefix $(PLUGINS_OBJ_DIR)/,$(addsuffix .o,$(SOURCES)))
+EXECUTABLE = $(addprefix $(PLUGINS_ELF_DIR)/,simple_plugin.so)
 
-all: simple_plugin
-
-.PHONY: $(EXECUTABLE)
-
-simple_plugin: $(EXECUTABLE)
+all: $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJ_FILES)
-	echo $(CPP) $(LDFLAGS) $(addprefix $(PLUGINS_OBJ_DIR)/,$(OBJ_FILES)) -o $(addprefix $(PLUGINS_ELF_DIR)/,$@)
-	$(CPP) $(LDFLAGS) $(addprefix $(PLUGINS_OBJ_DIR)/,$(OBJ_FILES)) -o $(addprefix $(PLUGINS_ELF_DIR)/,$@) $(addprefix -l,$(LIBS))
+	echo $(CPP) $(LDFLAGS) $(OBJ_FILES) -o $@
+	$(CPP) $(LDFLAGS) $(OBJ_FILES) -o $@ $(addprefix -l,$(LIBS))
 	$(ECHO) "\n  Plugin '"$@"' has been built successfully.\n"
 
-%.o: %.cpp
-	echo $(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
-	$(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
+$(addprefix $(PLUGINS_OBJ_DIR)/,%.o): %.cpp
+	echo $(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
+	$(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
 
-%.o: %.c
-	echo $(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
-	$(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
+$(addprefix $(PLUGINS_OBJ_DIR)/,%.o): %.c
+	echo $(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
+	$(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@

--- a/debugger/makefiles/make_socsim_plugin
+++ b/debugger/makefiles/make_socsim_plugin
@@ -8,7 +8,7 @@ include util.mak
 
 CC=gcc
 CPP=gcc
-CFLAGS= -c -Wall -Werror -fpic -std=c++0x
+CFLAGS=-g -c -Wall -Werror -fpic -std=c++0x
 LDFLAGS=-shared -L$(PLUGINS_ELF_DIR)/..
 INCL_KEY=-I
 DIR_KEY=-B
@@ -44,24 +44,20 @@ LIBS = \
 	dbg64g
 
 SRC_FILES = $(addsuffix .cpp,$(SOURCES))
-OBJ_FILES = $(addsuffix .o,$(SOURCES))
-EXECUTABLE = socsim_plugin.so
+OBJ_FILES = $(addprefix $(PLUGINS_OBJ_DIR)/,$(addsuffix .o,$(SOURCES)))
+EXECUTABLE = $(addprefix $(PLUGINS_ELF_DIR)/,socsim_plugin.so)
 
-all: socsim_plugin
-
-.PHONY: $(EXECUTABLE)
-
-socsim_plugin: $(EXECUTABLE)
+all: $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJ_FILES)
-	echo $(CPP) $(LDFLAGS) $(addprefix $(PLUGINS_OBJ_DIR)/,$(OBJ_FILES)) -o $(addprefix $(PLUGINS_ELF_DIR)/,$@)
-	$(CPP) $(LDFLAGS) $(addprefix $(PLUGINS_OBJ_DIR)/,$(OBJ_FILES)) -o $(addprefix $(PLUGINS_ELF_DIR)/,$@) $(addprefix -l,$(LIBS))
+	echo $(CPP) $(LDFLAGS) $(OBJ_FILES) -o $@
+	$(CPP) $(LDFLAGS) $(OBJ_FILES) -o $@ $(addprefix -l,$(LIBS))
 	$(ECHO) "\n  Plugin '"$@"' has been built successfully.\n"
 
-%.o: %.cpp
-	echo $(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
-	$(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
+$(addprefix $(PLUGINS_OBJ_DIR)/,%.o): %.cpp
+	echo $(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
+	$(CPP) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
 
-%.o: %.c
-	echo $(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
-	$(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $(addprefix $(PLUGINS_OBJ_DIR)/,$@)
+$(addprefix $(PLUGINS_OBJ_DIR)/,%.o): %.c
+	echo $(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@
+	$(CC) $(CFLAGS) $(addprefix $(INCL_KEY),$(INCL_PATH)) $< -o $@

--- a/debugger/makefiles/makefile
+++ b/debugger/makefiles/makefile
@@ -27,20 +27,20 @@ libdbg64g:
 	$(MKDIR) ./$(ELF_DIR)
 	$(MKDIR) ./$(PLUGINS_OBJ_DIR)
 	$(MKDIR) ./$(PLUGINS_ELF_DIR)
-	make -f make_libdbg64g TOP_DIR=$(TOP_DIR) OBJ_DIR=$(OBJ_DIR) ELF_DIR=$(ELF_DIR) $@ $(TEA)
+	make -f make_libdbg64g TOP_DIR=$(TOP_DIR) OBJ_DIR=$(OBJ_DIR) ELF_DIR=$(ELF_DIR) $(TEA)
 
 simple_plugin:
 	$(ECHO) "    Plugin " $@ " building started:"
-	make -f make_simple_plugin TOP_DIR=$(TOP_DIR) PLUGINS_OBJ_DIR=$(PLUGINS_OBJ_DIR) PLUGINS_ELF_DIR=$(PLUGINS_ELF_DIR) $@ $(TEA)
+	make -f make_simple_plugin TOP_DIR=$(TOP_DIR) PLUGINS_OBJ_DIR=$(PLUGINS_OBJ_DIR) PLUGINS_ELF_DIR=$(PLUGINS_ELF_DIR) $(TEA)
 
 socsim_plugin:
 	$(ECHO) "    Plugin " $@ " building started:"
-	make -f make_socsim_plugin TOP_DIR=$(TOP_DIR) PLUGINS_OBJ_DIR=$(PLUGINS_OBJ_DIR) PLUGINS_ELF_DIR=$(PLUGINS_ELF_DIR) $@ $(TEA)
+	make -f make_socsim_plugin TOP_DIR=$(TOP_DIR) PLUGINS_OBJ_DIR=$(PLUGINS_OBJ_DIR) PLUGINS_ELF_DIR=$(PLUGINS_ELF_DIR) $(TEA)
 
 cpu_fnc_plugin:
 	$(ECHO) "    Plugin " $@ " building started:"
-	make -f make_cpu_fnc_plugin TOP_DIR=$(TOP_DIR) PLUGINS_OBJ_DIR=$(PLUGINS_OBJ_DIR) PLUGINS_ELF_DIR=$(PLUGINS_ELF_DIR) $@ $(TEA)
+	make -f make_cpu_fnc_plugin TOP_DIR=$(TOP_DIR) PLUGINS_OBJ_DIR=$(PLUGINS_OBJ_DIR) PLUGINS_ELF_DIR=$(PLUGINS_ELF_DIR) $(TEA)
 
 appdbg64g:
 	$(ECHO) "    Debugger application building started:"
-	make -f make_appdbg64g TOP_DIR=$(TOP_DIR) OBJ_DIR=$(OBJ_DIR) ELF_DIR=$(ELF_DIR) $@ $(TEA)
+	make -f make_appdbg64g TOP_DIR=$(TOP_DIR) OBJ_DIR=$(OBJ_DIR) ELF_DIR=$(ELF_DIR) $(TEA)

--- a/debugger/src/appdbg64g/main.cpp
+++ b/debugger/src/appdbg64g/main.cpp
@@ -282,15 +282,19 @@ int main(int argc, char* argv[]) {
         /**
          * @brief Create instance of the example plugin class.
          */
-        itst = static_cast<IService *>(RISCV_create_service(
-                      RISCV_get_class("SimplePluginClass"), "example1", NULL));
+      IFace *simple = RISCV_get_class("SimplePluginClass");
+      if (simple)
+	itst = static_cast<IService *>(RISCV_create_service(
+                      simple, "example1", NULL));
     }
+
+    if (itst != NULL) {
     /** Get plugin specific interface. */
     ISimplePlugin * itst_access = static_cast<ISimplePlugin *>(
                                 itst->getInterface(IFACE_SIMPLE_PLUGIN));
     /** Call example method */
     itst_access->exampleAction(0xcafe);
-
+    }
 
     // Working cycle with console:
     IThread *in = static_cast<IThread *>(

--- a/debugger/src/libdbg64g/services/bus/bus.cpp
+++ b/debugger/src/libdbg64g/services/bus/bus.cpp
@@ -138,7 +138,7 @@ int Bus::write(uint64_t addr, uint8_t *payload, int sz) {
 void Bus::addBreakpoint(uint64_t addr) {
     AttributeType br(Attr_UInteger, addr);
     for (unsigned i = 0; i < breakpoints_.size(); i++) {
-        if (breakpoints_[i].to_uint64() == ~0) {
+      if (breakpoints_[i].to_uint64() == (unsigned)~0) {
             breakpoints_[i] = br;
             return;
         }

--- a/debugger/src/libdbg64g/services/udp/udp.cpp
+++ b/debugger/src/libdbg64g/services/udp/udp.cpp
@@ -68,45 +68,22 @@ int UdpService::createDatagramSocket() {
         return -1;
     }
 
-    struct addrinfo hints;
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_protocol = IPPROTO_TCP;
-
-    int retval;
-    struct addrinfo *result = NULL;
-    struct addrinfo *ptr = NULL;
-    retval = getaddrinfo(hostName, "0", &hints, &result);
-    if (retval != 0) {
-        return -1;
-    }
-
-    for (ptr = result; ptr != NULL; ptr = ptr->ai_next) {
-        // Find only IPV4 address, ignore others.
-        if (ptr->ai_family != AF_INET) {
-            continue;
-        }
-        sockaddr_ipv4_ = *((struct sockaddr_in *)ptr->ai_addr);
-        RISCV_sprintf(sockaddr_ipv4_str_, sizeof(sockaddr_ipv4_str_), 
-                    "%s", inet_ntoa(sockaddr_ipv4_.sin_addr));
-
-        if (strcmp(inet_ntoa(sockaddr_ipv4_.sin_addr), 
-                   hostIP_.to_string()) == 0) {
-            break;
-        }
-    }
-
+    memset(&sockaddr_ipv4_, 0, sizeof (sockaddr_ipv4_));
+    sockaddr_ipv4_.sin_family = AF_INET;
+    inet_aton(hostIP_.to_string(), &(sockaddr_ipv4_.sin_addr));
     hsock_ = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (hsock_ < 0) {
+        perror("Fatal error: socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)");
         //setLibError(ERR_UDPSOCKET_CREATE);
         return -1;
     }
 
-    sockaddr_ipv4_.sin_port = 0;
     int res = bind(hsock_, (struct sockaddr *)&sockaddr_ipv4_, 
                               sizeof(sockaddr_ipv4_));
     if (res != 0) {
+      char err[99];
+      sprintf(err, "Fatal error: bind(hsock_, \"%s\", ...)", hostIP_.to_string());
+      perror(err);
         //setLibError(ERR_UDPSOCKET_BIND);
         return -1;
     }


### PR DESCRIPTION
Dear Sergey,
 Thank you for sharing this very interesting project. The idea of using ethernet for debugging is very advanced and at the same time straightforward. However since you work mostly on Windows you may not have noticed some issues on Linux, specifically, not checking for dereferencing NULL pointers, not specifically targeting the correct IP address when binding the socket, and overwriting the same object file during compilation with a different compilation flag, also phony targets meaning the entire debugger has to be rebuilt every time. I believe these changes are of general benefit for your next version, however I cannot say if the Windows behaviour will be compromised, so I won't be at all offended if you don't accept them.

Regards,
Dr Jonathan Kimmitt MA PhD CEng MIET
Research Associate
Computational Chemistry
University of Cambridge

Commitlog
___________

Correct dependencies in various makefiles. Add -g flags globally to detect
crash causes. Force listen command to use correct IP address. Inform if no
appropriate IP is available.