### PR TITLE
Fix Vivado simulation

### DIFF
--- a/rtl/riverlib/core/regibank.vhd
+++ b/rtl/riverlib/core/regibank.vhd
@@ -72,7 +72,9 @@ begin
 
     if i_nrst = '0' then
         v.mem(Reg_Zero) := (others => '0');
-        v.mem(1 to Reg_Total-1) := (others => X"00000000FEEDFACE");
+        for i in 1 to Reg_Total-1 loop
+            v.mem(i) := X"00000000FEEDFACE";
+        end loop;
     end if;
 
     rin <= v;


### PR DESCRIPTION
The previous code, although completely valid, causes the Vivado simulator to crash. This change allows the core to be simulated properly.

I have also reported the bug to Xilinx here: https://forums.xilinx.com/t5/Simulation-and-Verification/Vivado-crash-in-simulation-with-valid-VHDL/m-p/879353